### PR TITLE
Format update (for ID 62xxxxx onwards)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ Verified by MUICT staff.
 ## Updates:
 
 - Oct 14, 2021: Updated the format to follow the FGS instructions.
+- Dec 19, 2024: Updated the format (for ID 62xxxxx onwards):
+    - **Abstract**: add 1 line space before the abstract heading
+    - **Implication**: add 1 line space before keywords
+    - **Table of Contents**: add 2cm indentation for sections, and 4cm for subsections.
+    - **References**: (1) add 2cm indentation for biblabel, starting from the second line (2) fix ordering number style (3) fix all-caps header on even pages (4) fix references not showing in ToC.
+    - **Biography** remove hspace before degrees.

--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,5 @@
 \documentclass{muthesis2021}
-\usepackage[numbers]{natbib}
+% \usepackage[numbers]{natbib}
 \setcounter{secnumdepth}{4} % make subsubsection have numberings
 \usepackage{graphicx}
 \usepackage{latexsym}
@@ -59,8 +59,8 @@
 % put appendices here
 
 % file containing refs if you are not using bibtex
-% \bibliographystyle{muthesis2021}
-\bibliographystyle{unsrtnat}
+\bibliographystyle{muthesis2021}
+% \bibliographystyle{unsrtnat}
 
 \bibliography{references}
 

--- a/muthesis2021.cls
+++ b/muthesis2021.cls
@@ -536,7 +536,8 @@
 	\MakeUppercase\@coadvisorII, \@coadvisorIIletters\
         } \\ %(\MakeUppercase\@coadvisorIIsubject)} \\
        \end{flushleft}
-  \vspace{-3ex}													% Reduce too much line spacing before ABSTRACT
+%   \vspace{-3ex}													% Reduce too much line spacing before ABSTRACT
+	\vspace{-1ex}
 	\begin{center}ABSTRACT\end{center}
 	\vspace{-0.8em}
 %	\@beginparpenalty\@lowpenalty
@@ -546,9 +547,10 @@
         \@abstractbox
 	\begin{center}IMPLICATION OF THE THESIS\end{center}
 	\par #2
-	\vspace{-0.8em}
+	% \vspace{-0.8em}
 
-	\vspace{0.5em}
+	% \vspace{0.5em}
+	\vspace{1em}
         \begin{tabbing}
 	KEY WORDS~: \= \MakeTextUppercase\@keywords \\
 	\ifthenelse{\equal{\@keywordsII}{}}{}{
@@ -635,6 +637,10 @@
   \fi}
 
 % \@chapter ตัวปัญหาที่ทำให้ใช้ hyperref package ไม่ได้
+
+% reformatting section/subsection entries in toc
+\renewcommand*\l@section{\@dottedtocline{1}{2cm}{2em}}
+\renewcommand*\l@subsection{\@dottedtocline{1}{4cm}{2.5em}}
 
 \def\@chapter[#1]#2{%
 	\ifnum \c@secnumdepth >\m@ne
@@ -887,6 +893,8 @@
   \gdef\@chapapp{\appendixname}%
   \gdef\thechapter{\@Alph\c@chapter}}
 
+\renewcommand{\@biblabel}[1]{#1}
+
 \renewenvironment{thebibliography}[1]{
 	\chapter*{\bibname}
 	\addcontentsline{toc}{chapter}{\MakeUppercase{\bibname}}
@@ -942,7 +950,8 @@
 	{\bf PLACE OF BIRTH} \>\@placeofbirth \\
 	{\bf INSTITUTIONS ATTENDED} \>\@firstdegreeinstitution,
 	\@firstdegreeyears \\
-	\>\hspace{1cm}\=\@firstdegree\
+	% \>\hspace{1cm}\=\@firstdegree\
+	\>\=\@firstdegree\
 % the extra `(' seems to be necessary -- some bug in LaTeX???
         \ifthenelse{\boolean{@longfirstdegree}}{ \\ \>\> (}%
 	(\@firstdegreemajor) \\


### PR DESCRIPTION
Format update (for ID 62xxxxx onwards):
- **Abstract**: add 1 line space before the abstract heading
- **Implication**: add 1 line space before keywords
- **Table of Contents**: add 2cm indentation for sections, and 4cm for subsections.
- **References**:
    1. add 2cm indentation for biblabel, starting from the second line
    2. fix ordering number style
    3. fix all-caps header on even pages
    4. fix references not showing in ToC.
- **Biography**: remove hspace before degrees.

To resolve the issue where bibliography is not shown in the ToC, I decided not to use *natbib* and stick to MuThesis2021 styling instead. Not sure how this would affect other packages, please kindly help revise this.

Thank you so much!

Krittanat Sutassananon (ITCS/D 6238440)
Thesis submission approved by FGS on 19 December 2024.